### PR TITLE
Isolated JSON settings to library

### DIFF
--- a/AmplitudeSharp/AmplitudeSharp.csproj
+++ b/AmplitudeSharp/AmplitudeSharp.csproj
@@ -34,8 +34,9 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
The current library sets JSON serialization settings on the static JsonConvert.DefaultSettings instance, which affects JSON serialization for the entire app (and across different threads if the app is multi-threaded).

This means that using the library will corrupt JSON data sent over by either other libraries or the app itself if any of the settings are different amongst them (which in general they are).

Instead the library should use its own isolated JSON serialization settings so that consuming apps and other libraries can use whatever settings they need without affecting each other.